### PR TITLE
add support to env variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "easy-crypto",
+  "name": "quick-crypto",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "easy-crypto",
+      "name": "quick-crypto",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/src/easy-crypto.ts
+++ b/src/easy-crypto.ts
@@ -3,7 +3,8 @@ import * as crypto from "crypto";
 
 const defaultIv = "5fbe50e741c064f8";
 const defaultKey = "011b73647d13adbafa9351fdb1ec0698";
-
+const getIv = () => process.env.EASY_CRYPTO_IV || defaultIv;
+const getKey = () => process.env.EASY_CRYPTO_KEY || defaultKey;
 
 /**
  * cipher the properties defined in the second parameter.
@@ -26,8 +27,8 @@ function cipherObject<T extends Record<string, any>>(
   keyCipher?: string,
   iv?: string
 ): T {
-  keyCipher = keyCipher ? keyCipher : defaultKey;
-  iv = iv ? iv : defaultIv;
+  keyCipher = keyCipher ? keyCipher : getKey();
+  iv = iv ? iv : getIv();
   propertiesToEncrypt = propertiesToEncrypt
     ? propertiesToEncrypt
     : Object.keys(obj);
@@ -67,8 +68,12 @@ function cipherObjects<T extends Record<string, any>>(
   keyCipher?: string,
   iv?: string
 ): T[] {
-  keyCipher = keyCipher ? keyCipher : defaultKey;
-  iv = iv ? iv : defaultIv;
+  keyCipher = keyCipher ? keyCipher : getKey();
+  iv = iv ? iv : getIv();
+  console.log("current Key: ", getKey());
+  console.log("current Iv: ", getIv());
+  console.log("request Key: ", keyCipher);
+  console.log("request iv: ", iv);
   for (let obj of objects) {
     propertiesToEncrypt = propertiesToEncrypt
       ? propertiesToEncrypt
@@ -109,8 +114,8 @@ function decipherObject<T extends Record<string, any>>(
   keyCipher?: string,
   iv?: string
 ): T {
-  keyCipher = keyCipher ? keyCipher : defaultKey;
-  iv = iv ? iv : defaultIv;
+  keyCipher = keyCipher ? keyCipher : getKey();
+  iv = iv ? iv : getIv();
   propertiesToDecrypt = propertiesToDecrypt
     ? propertiesToDecrypt
     : Object.keys(obj);
@@ -149,8 +154,12 @@ function decipherObjects<T extends Record<string, any>>(
   keyCipher?: string,
   iv?: string
 ): T[] {
-  keyCipher = keyCipher ? keyCipher : defaultKey;
-  iv = iv ? iv : defaultIv;
+  console.log("current Key: ", getKey());
+  console.log("current Iv: ", getIv());
+  console.log("request Key: ", keyCipher);
+  console.log("request iv: ", iv);
+  keyCipher = keyCipher ? keyCipher : getKey();
+  iv = iv ? iv : getIv();
   for (let obj of objects) {
     propertiesToDecrypt = propertiesToDecrypt
       ? propertiesToDecrypt
@@ -183,8 +192,8 @@ function decipherObjects<T extends Record<string, any>>(
  */
 
 function cipherValue(value: string, keyCipher?: string, iv?: string): string {
-  keyCipher = keyCipher ? keyCipher : defaultKey;
-  iv = iv ? iv : defaultIv;
+  keyCipher = keyCipher ? keyCipher : getKey();
+  iv = iv ? iv : getIv();
   const cipher = createCipheriv("aes256", keyCipher, iv);
   const encrypted = cipher.update(value, "utf-8", "hex") + cipher.final("hex");
 
@@ -208,8 +217,8 @@ function cipherValues(
   keyCipher?: string,
   iv?: string
 ): string[] {
-  keyCipher = keyCipher ? keyCipher : defaultKey;
-  iv = iv ? iv : defaultIv;
+  keyCipher = keyCipher ? keyCipher : getKey();
+  iv = iv ? iv : getIv();
   const res: string[] = [];
   for (let value of values) {
     const cipher = createCipheriv("aes256", keyCipher, iv);
@@ -233,8 +242,8 @@ function cipherValues(
  */
 
 function decipherValue(value: string, keyCipher?: string, iv?: string): string {
-  keyCipher = keyCipher ? keyCipher : defaultKey;
-  iv = iv ? iv : defaultIv;
+  keyCipher = keyCipher ? keyCipher : getKey();
+  iv = iv ? iv : getIv();
   const decipher = createDecipheriv("aes256", keyCipher, iv);
   const decrypted =
     decipher.update(value, "hex", "utf-8") + decipher.final("utf-8");
@@ -259,8 +268,8 @@ function decipherValues(
   keyCipher?: string,
   iv?: string
 ): string[] {
-  keyCipher = keyCipher ? keyCipher : defaultKey;
-  iv = iv ? iv : defaultIv;
+  keyCipher = keyCipher ? keyCipher : getKey();
+  iv = iv ? iv : getIv();
   const res: string[] = [];
   for (let value of values) {
     const decipher = createDecipheriv("aes256", keyCipher, iv);

--- a/tests/easy-crypto.test.ts
+++ b/tests/easy-crypto.test.ts
@@ -27,6 +27,11 @@ const objectsList: any[] = [
 ];
 
 describe("EasyCrypto lib tests", () => {
+  beforeEach(() => {
+    delete process.env.EASY_CRYPTO_KEY;
+    delete process.env.EASY_CRYPTO_IV;
+  });
+
   it("should return an object with { key: string64len, iv: string32len }", () => {
     expect(generateKeyAndIv()).toEqual(
       expect.objectContaining({
@@ -87,4 +92,22 @@ describe("EasyCrypto lib tests", () => {
       })
     );
   })
+
+  it("should use env variables to set key and iv", () => {
+    process.env.EASY_CRYPTO_KEY = "12345678901234567890123456789012";
+    process.env.EASY_CRYPTO_IV = "1234567890123456";
+    const arr = objectsList.map(o => o[0]);
+    const ciphers = cipherObjects(arr);
+    expect(Array.isArray(ciphers)).toBeTruthy();
+    expect(decipherObjects(ciphers, undefined, process.env.EASY_CRYPTO_KEY, process.env.EASY_CRYPTO_IV)).toEqual(arr);
+  });
+
+  it("should use default key and iv if not given", () => {
+    const arr = objectsList.map(o => o[0]);
+    const ciphers = cipherObjects(arr);
+    expect(Array.isArray(ciphers)).toBeTruthy();
+    const defaultKey = getDefaultKeyAndIv().key;
+    const defaultIv = getDefaultKeyAndIv().iv;
+    expect(decipherObjects(ciphers, undefined, defaultKey, defaultIv)).toEqual(arr);
+  });
 });


### PR DESCRIPTION
The idea is that the person who uses this library do not need to explicitly specify the Key and Iv in order to use its own key. Besides that env variables make it possible to use it as a secret and making it more suitable for production environments.